### PR TITLE
Fix 546

### DIFF
--- a/app/Concerns/HasBirthdate.php
+++ b/app/Concerns/HasBirthdate.php
@@ -17,8 +17,8 @@ trait HasBirthdate
 
     public function setBirthdateAttribute(?string $value = null): void
     {
-        $date = $value ? Carbon::createFromFormat('d.m.Y', $value) : null;
+        $date = $value ? Carbon::parse($value)->format('Y-m-d') : null;
 
-        $this->attributes['birthdate'] = $date?->format('Y-m-d');
+        $this->attributes['birthdate'] = $date;
     }
 }

--- a/app/Concerns/HasBirthdate.php
+++ b/app/Concerns/HasBirthdate.php
@@ -17,8 +17,8 @@ trait HasBirthdate
 
     public function setBirthdateAttribute(?string $value = null): void
     {
-        $date = $value ? Carbon::parse($value)->format('Y-m-d') : null;
+        $date = $value ? Carbon::createFromFormat('d.m.Y', $value) : null;
 
-        $this->attributes['birthdate'] = $date;
+        $this->attributes['birthdate'] = $date?->format('Y-m-d');
     }
 }

--- a/app/Filament/Organizations/Resources/BeneficiaryResource/Pages/EditBeneficiaryIdentity.php
+++ b/app/Filament/Organizations/Resources/BeneficiaryResource/Pages/EditBeneficiaryIdentity.php
@@ -152,9 +152,6 @@ class EditBeneficiaryIdentity extends EditRecord
 
                     DatePicker::make('birthdate')
                         ->label(__('field.birthdate'))
-                        ->dehydrateStateUsing(function ($state) {
-                            return Carbon::createFromFormat('Y-m-d', $state)->format('d.m.Y');
-                        })
                         ->live(),
 
                     TextInput::make('birthplace')

--- a/app/Filament/Organizations/Resources/BeneficiaryResource/Pages/EditBeneficiaryIdentity.php
+++ b/app/Filament/Organizations/Resources/BeneficiaryResource/Pages/EditBeneficiaryIdentity.php
@@ -20,6 +20,7 @@ use App\Forms\Components\Spacer;
 use App\Models\Beneficiary;
 use App\Rules\ValidCNP;
 use App\Services\Breadcrumb\BeneficiaryBreadcrumb;
+use Carbon\Carbon;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Hidden;
@@ -151,7 +152,11 @@ class EditBeneficiaryIdentity extends EditRecord
 
                     DatePicker::make('birthdate')
                         ->label(__('field.birthdate'))
-                        ->live(),
+                        ->live()
+                        ->dehydrateStateUsing(
+                            fn (string $state) => Carbon::parse($state)->format('d.m.Y')
+                        )
+                    ,
 
                     TextInput::make('birthplace')
                         ->label(__('field.birthplace'))

--- a/app/Filament/Organizations/Resources/BeneficiaryResource/Pages/EditBeneficiaryIdentity.php
+++ b/app/Filament/Organizations/Resources/BeneficiaryResource/Pages/EditBeneficiaryIdentity.php
@@ -20,7 +20,6 @@ use App\Forms\Components\Spacer;
 use App\Models\Beneficiary;
 use App\Rules\ValidCNP;
 use App\Services\Breadcrumb\BeneficiaryBreadcrumb;
-use Carbon\Carbon;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Hidden;

--- a/app/Filament/Organizations/Resources/BeneficiaryResource/Pages/EditBeneficiaryIdentity.php
+++ b/app/Filament/Organizations/Resources/BeneficiaryResource/Pages/EditBeneficiaryIdentity.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Filament\Organizations\Resources\BeneficiaryResource\Pages;
 
-use alcea\cnp\Cnp;
 use App\Concerns\PreventSubmitFormOnEnter;
 use App\Concerns\RedirectToIdentity;
 use App\Enums\AddressType;
@@ -21,12 +20,13 @@ use App\Forms\Components\Spacer;
 use App\Models\Beneficiary;
 use App\Rules\ValidCNP;
 use App\Services\Breadcrumb\BeneficiaryBreadcrumb;
+use Carbon\Carbon;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Section;
-use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Textarea;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
@@ -35,6 +35,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Unique;
+use alcea\cnp\Cnp;
 
 class EditBeneficiaryIdentity extends EditRecord
 {
@@ -151,6 +152,9 @@ class EditBeneficiaryIdentity extends EditRecord
 
                     DatePicker::make('birthdate')
                         ->label(__('field.birthdate'))
+                        ->dehydrateStateUsing(function ($state) {
+                            return Carbon::createFromFormat('Y-m-d', $state)->format('d.m.Y');
+                        })
                         ->live(),
 
                     TextInput::make('birthplace')

--- a/app/Filament/Organizations/Resources/BeneficiaryResource/Pages/EditChildrenIdentity.php
+++ b/app/Filament/Organizations/Resources/BeneficiaryResource/Pages/EditChildrenIdentity.php
@@ -198,6 +198,9 @@ class EditChildrenIdentity extends EditRecord
                                 report: false
                             ));
                         })
+                        ->dehydrateStateUsing(
+                            fn (string $state) => Carbon::parse($state)->format('d.m.Y')
+                        )
                         ->live(),
 
                     TextInput::make('age')

--- a/app/Filament/Organizations/Resources/MonitoringResource/Pages/EditChildren.php
+++ b/app/Filament/Organizations/Resources/MonitoringResource/Pages/EditChildren.php
@@ -14,11 +14,12 @@ use App\Forms\Components\DatePicker;
 use App\Forms\Components\Repeater;
 use App\Forms\Components\Select;
 use App\Services\Breadcrumb\BeneficiaryBreadcrumb;
+use Carbon\Carbon;
 use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Section;
-use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Textarea;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Resources\Pages\EditRecord;
@@ -86,7 +87,11 @@ class EditChildren extends EditRecord
                                 ->mask('99'),
 
                             DatePicker::make('birthdate')
-                                ->label(__('monitoring.labels.birthdate')),
+                                ->label(__('monitoring.labels.birthdate'))
+                                ->dehydrateStateUsing(
+                                    fn (string $state) => Carbon::parse($state)->format('d.m.Y')
+                                )
+                                ,
 
                             Select::make('aggressor_relationship')
                                 ->label(__('monitoring.labels.aggressor_relationship'))


### PR DESCRIPTION
Fixes #546 

This PR fixes an issue with formatting the birthdate before saving to the database.

The `DatePicker` component has `Y-m-d` as the default format, but in the `HasBirthdate` trait the format is required to be `d.m.Y`, in order to be properly saved.